### PR TITLE
force port 8080 exposure on first node start-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@ For the multi node Hadoop cluster instructions please read our [blog](http://blo
 curl -Lo .amb j.mp/docker-ambari && . .amb && amb-deploy-cluster
 ```
 
-_Note: there is a 1.7.0 Ambari early access in the v1.7.0-ea branch. if you are interested in a particular Ambari version, always check for the appropriate branch._
+_Note: If you are interested in a particular Ambari version, always check for the appropriate branch._
 
 [![githalytics.com alpha](https://cruel-carlota.pagodabox.com/cf81b5b79a6a27e8b10daf467c576d87 "githalytics.com")](http://githalytics.com/sequenceiq/docker-ambari)

--- a/ambari-functions
+++ b/ambari-functions
@@ -111,7 +111,7 @@ amb-deploy-cluster() {
 }
 
 amb-start-first() {
-  run-command docker run -d $DOCKER_OPTS --name $AMBARI_SERVER_NAME -h $AMBARI_SERVER_NAME.$MYDOMAIN $IMAGE --tag ambari-server=true
+  run-command docker run -d $DOCKER_OPTS -p 8080 --name $AMBARI_SERVER_NAME -h $AMBARI_SERVER_NAME.$MYDOMAIN $IMAGE --tag ambari-server=true
 }
 
 amb-copy-to-hdfs() {


### PR DESCRIPTION
When leveraging the ambari-functions script, and the one-liner referenced here: http://blog.sequenceiq.com/blog/2014/06/19/multinode-hadoop-cluster-on-docker/ I kept encountering issues where I could not access amb0:8080 URL to enter the ambari UI.

When using docker 1.4.1, I could not expose port 8080 from the ambari master with the following docker command: docker port amb0 8080. This command should expose port 8080 from the designated container. It faults out. There are other work-arounds to expose the container port, but directly informing docker to expose 8080 via -p flag in ambari-functions script for the first node only seemed to be the least intrusive fix. Doing this does hard-code 8080 as exposure, but 8080 is the default port for ambari UI.

Setting the port exposure in DOCKER_OPTS variable would reflect on all nodes, which is what we don't want. Isolating this to only the first node (master node) is viable.

Submitting for inclusion. Welcome to hear other ideas too.

Fixed README reference to invalid branch of 1.7.0-ea as well.