### PR TITLE
Add ZSH support for ambari-functions

### DIFF
--- a/ambari-functions
+++ b/ambari-functions
@@ -9,7 +9,7 @@ USAGE
 : ${NODE_PREFIX=amb}
 : ${AMBARI_SERVER_NAME:=${NODE_PREFIX}0}
 : ${MYDOMAIN:=mycorp.kom}
-: ${IMAGE:="sequenceiq/ambari:1.6.0"}
+: ${IMAGE:="sequenceiq/ambari:1.7.0"}
 : ${DOCKER_OPTS:="--dns 127.0.0.1 --entrypoint /usr/local/serf/bin/start-serf-agent.sh -e KEYCHAIN=$KEYCHAIN"}
 : ${CLUSTER_SIZE:=3}
 : ${DEBUG:=1}
@@ -18,11 +18,11 @@ USAGE
 
 run-command() {
   CMD="$@"
-  if [ "$DRY_RUN" == "false" ]; then
+  if [[ "$DRY_RUN" = "false" ]]; then
     debug "$CMD"
     "$@"
   else
-    debug [DRY_RUN] "$CMD"
+    debug "[DRY_RUN]" "$CMD"
   fi
 }
 
@@ -58,7 +58,7 @@ EOF
 }
 
 debug() {
-  [ $DEBUG -gt 0 ] && echo [DEBUG] "$@" 1>&2
+  [[ $DEBUG -gt 0 ]] && echo -e "[DEBUG]" "$@" 1>&2
 }
 
 docker-ps() {
@@ -77,7 +77,7 @@ amb-start-cluster() {
   echo starting an ambari cluster with: $act_cluster_size nodes
 
   amb-start-first
-  [ $act_cluster_size -gt 1 ] && for i in $(seq $((act_cluster_size - 1))); do
+  [[ $act_cluster_size -gt 1 ]] && for i in $(seq $((act_cluster_size - 1))); do
     amb-start-node $i
   done
 }
@@ -142,7 +142,7 @@ amb-start-node() {
   get-ambari-server-ip
   : ${AMBARI_SERVER_IP:?"AMBARI_SERVER_IP is needed"}
   NUMBER=${1:?"please give a <NUMBER> parameter it will be used as node<NUMBER>"}
-  if [ $# -eq 1 ] ;then
+  if [[ $# -eq 1 ]] ;then
     MORE_OPTIONS="-d"
   else
     shift


### PR DESCRIPTION
[Issue #18]

AFAIK this allows ambari-functions to run as expected in
ZSH v5.0.5.

- Minor edits to if conditional statements to run on ZSH

- Update base image from ambari 1.6.0 to 1.7.0