### PR TITLE
fix jdk version mismatch

### DIFF
--- a/ambari-server/ambari-shell.sh
+++ b/ambari-server/ambari-shell.sh
@@ -7,4 +7,5 @@ echo AMBARI_HOST=${AMBARI_HOST:? ambari server address is mandatory, fallback is
 
 ./wait-for-host-number.sh
 
+export PATH=/usr/jdk64/jdk1.7.0_67/bin:$PATH
 java -jar ambari-shell.jar --ambari.host=$AMBARI_HOST


### PR DESCRIPTION
If I just run the /tmp/ambari-shell.sh, the jdk version mismatched, so I just fix this according the install-cluster.sh.