### PR TITLE
Fix public hostname script for private EC2 instances

### DIFF
--- a/ambari-server/public-hostname.sh
+++ b/ambari-server/public-hostname.sh
@@ -7,9 +7,10 @@ if [ -n "$GCC" ]; then
   exit 0
 fi
 
+AWS_STATUS=$(curl -s -m 5 -w "%{http_code}" http://169.254.169.254/latest/meta-data/public-hostname -o /dev/null)
 AWS=$(curl -s -m 5 http://169.254.169.254/latest/meta-data/public-hostname)
 
-if [ -n "$AWS" ]; then
+if [ "$AWS_STATUS" == "200" ] && [ -n "$AWS" ]; then
   echo $AWS
   exit 0
 fi


### PR DESCRIPTION
Right now, the method of determining public hostnames fails on private EC2 instances, returning the 404 page for a missing instance metadata attribute, and thus breaking cluster setup on private EC2 instances.

```
# sh public-hostname.sh 
<?xml version="1.0" encoding="iso-8859-1"?> <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"> <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"> <head> <title>404 - Not Found</title> </head> <body> <h1>404 - Not Found</h1> </body> </html>
```

This change checks to make sure the `/public-hostname` endpoint is available by testing its HTTP response code. If on a private EC2 instance, the endpoint will respond, but it will return a 404 HTTP status code, and so we fall back to `hostname -f`. 

On public EC2 instances, the behavior remains the same as before.

Not sure if you'd prefer for this to be implemented differently. Just let me know.