### PR TITLE
Simplify tailing

### DIFF
--- a/ambari-server/start-agent
+++ b/ambari-server/start-agent
@@ -35,10 +35,7 @@ main() {
   set-server-ip
   ambari-agent start -v
   /etc/init.d/sshd start
-  while true; do
-    sleep 3
-    tail -f /var/log/ambari-agent/ambari-agent.log
-  done
+  tail -F /var/log/ambari-agent/ambari-agent.log
 }
 
 main "$@"

--- a/ambari-server/start-server
+++ b/ambari-server/start-server
@@ -65,10 +65,7 @@ main() {
   reorder_dns_lookup
   config-remote-jdbc
   start_ambari
-  while true; do
-    sleep 3
-    tail -f /var/log/ambari-server/ambari-server.log
-  done
+  tail -F /var/log/ambari-server/ambari-server.log
 }
 
 main "$@"


### PR DESCRIPTION
Simpler is better :) Was there a reason to use a sleep loop with -f? Maybe to avoid 'file not yet there' message from tail?