### PR TITLE
Update the used Ambari blueprint version to latest

### DIFF
--- a/ambari-server/shell/install-cluster.sh
+++ b/ambari-server/shell/install-cluster.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 ./ambari-shell.sh << EOF
-blueprint add --url https://raw.githubusercontent.com/sequenceiq/ambari-rest-client/2.1.11/src/main/resources/blueprints/multi-node-hdfs-yarn
-blueprint add --url https://raw.githubusercontent.com/sequenceiq/ambari-rest-client/2.1.11/src/main/resources/blueprints/single-node-hdfs-yarn
+blueprint add --url https://raw.githubusercontent.com/sequenceiq/ambari-rest-client/2.2.8/src/main/resources/blueprints/multi-node-hdfs-yarn
+blueprint add --url https://raw.githubusercontent.com/sequenceiq/ambari-rest-client/2.2.8/src/main/resources/blueprints/single-node-hdfs-yarn
 cluster build --blueprint $BLUEPRINT
 cluster autoAssign
 cluster create --exitOnFinish true


### PR DESCRIPTION
The most recent version of ambari-shell reports errors
on unreferenced entries in the blueprints. The original
blueprint (ambari-rest-client v2.1.11) contained entries
for nagios which is not in use anymore.

Error message was:
Specified configuration type is not associated with any service:
nagios-env